### PR TITLE
added ways to set ApiKeys values

### DIFF
--- a/ClickUp.Net/ClickUpApi.cs
+++ b/ClickUp.Net/ClickUpApi.cs
@@ -6,36 +6,36 @@ using System.Text.Json;
 
 namespace Boson.ClickUp.Net
 {
-	public class ClickUpApi
-	{
-		private readonly HttpClient client;
-		private string OAuthToken = string.Empty;
-		private string Token = string.Empty;
-		private string Endpoint = "https://api.clickup.com/api/v2";
-		private string ApiV2Endpoint = "https://api.clickup.com/api/v2";
-		private string ApiMockServer = "https://a00fb6e0-339c-4201-972f-503b9932d17a.remockly.com";
-		private ApiKeys ApiKeys = new ApiKeys();
+  public class ClickUpApi
+  {
+    private readonly HttpClient client;
+    private string OAuthToken = string.Empty;
+    private string Token = string.Empty;
+    private string Endpoint = "https://api.clickup.com/api/v2";
+    private string ApiV2Endpoint = "https://api.clickup.com/api/v2";
+    private string ApiMockServer = "https://a00fb6e0-339c-4201-972f-503b9932d17a.remockly.com";
+    private ApiKeys ApiKeys = new ApiKeys();
 
-		public ClickUpApi()
-		{
-			var handler = new SocketsHttpHandler
-			{
-				PooledConnectionLifetime = TimeSpan.FromMinutes(15) // Recreate every 15 minutes
-			};
-			client = new HttpClient(handler);
+    public ClickUpApi()
+    {
+      var handler = new SocketsHttpHandler
+      {
+        PooledConnectionLifetime = TimeSpan.FromMinutes(15) // Recreate every 15 minutes
+      };
+      client = new HttpClient(handler);
 
-			#region [ Load settings ]
+      #region [ Load settings ]
 
-			//var settingsPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(ClickUpApi)).Location);
-			//var settingsFile = "appsettings.json";
-			//var settingsData = File.ReadAllText(Path.Combine(settingsPath, settingsFile));
-			//var settings = JsonSerializer.Deserialize<Settings>(settingsData);
-			//var settings = new Settings();
-			//settings.PersonalToken = "pk_57147343_2AJ8N0LLIOPU8FYDFFK2MYPQ1OD5L43L";
-			//Token = settings.PersonalToken;
+      //var settingsPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(ClickUpApi)).Location);
+      //var settingsFile = "appsettings.json";
+      //var settingsData = File.ReadAllText(Path.Combine(settingsPath, settingsFile));
+      //var settings = JsonSerializer.Deserialize<Settings>(settingsData);
+      //var settings = new Settings();
+      //settings.PersonalToken = "pk_57147343_2AJ8N0LLIOPU8FYDFFK2MYPQ1OD5L43L";
+      //Token = settings.PersonalToken;
 
-			#endregion [ Load settings ]
-		}
+      #endregion [ Load settings ]
+    }
 
     public ClickUpApi(string clientId, string clientSecret, string personalToken)
     {
@@ -44,13 +44,13 @@ namespace Boson.ClickUp.Net
         PooledConnectionLifetime = TimeSpan.FromMinutes(15) // Recreate every 15 minutes
       };
       client = new HttpClient(handler);
-			
-			ApiKeys = new ApiKeys()
-			{
-				ClientID = clientId,
-				ClientSecret = clientSecret,
-				PersonalToken = personalToken
-			};
+
+      ApiKeys = new ApiKeys()
+      {
+        ClientID = clientId,
+        ClientSecret = clientSecret,
+        PersonalToken = personalToken
+      };
 
       #region [ Load settings ]
 
@@ -66,238 +66,238 @@ namespace Boson.ClickUp.Net
     }
 
     public ClickUpApi UsingMockServer()
-		{
-			Endpoint = ApiMockServer;
-			return this;
-		}
+    {
+      Endpoint = ApiMockServer;
+      return this;
+    }
 
-		public ClickUpApi UsingV2Api()
-		{
-			Endpoint = ApiV2Endpoint;
-			return this;
-		}
+    public ClickUpApi UsingV2Api()
+    {
+      Endpoint = ApiV2Endpoint;
+      return this;
+    }
 
-		#region [ Authorization ]
+    #region [ Authorization ]
 
-		//TODO: GetAccessToken()
-		//public async Task GetAccessToken()
-		//{
-		//	var request = await client.PostAsync($"https://api.clickup.com/api/v2/oauth/token?client_id={ClientID}&client_secret={ClientSecret}&code={PersonalToken}", null);
-		//	var response = await request.Content.ReadAsStringAsync();
+    //TODO: GetAccessToken()
+    //public async Task GetAccessToken()
+    //{
+    //	var request = await client.PostAsync($"https://api.clickup.com/api/v2/oauth/token?client_id={ClientID}&client_secret={ClientSecret}&code={PersonalToken}", null);
+    //	var response = await request.Content.ReadAsStringAsync();
 
-		//	Console.WriteLine(response);
-		//}
+    //	Console.WriteLine(response);
+    //}
 
-		public async Task<Response<User>> GetAuthorizedUser()
-		{
-			var response = new Response<User>();
-			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
+    public async Task<Response<User>> GetAuthorizedUser()
+    {
+      var response = new Response<User>();
+      client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
-			var request = await client.GetAsync($"{Endpoint}/user");
-			var httpResponse = await request.Content.ReadAsStringAsync();
+      var request = await client.GetAsync($"{Endpoint}/user");
+      var httpResponse = await request.Content.ReadAsStringAsync();
 
-			response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
-			if (!response.Error.IsError)
-			{
-				var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
-				response.Value = myDeserializedClass.user;
-			}
+      response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
+      if (!response.Error.IsError)
+      {
+        var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
+        response.Value = myDeserializedClass.user;
+      }
 
-			//Console.WriteLine(response);
-			return response;
-		}
+      //Console.WriteLine(response);
+      return response;
+    }
 
-		public async Task<Response<IEnumerable<Team>>> GetAuthorizedTeams()
-		{
-			var response = new Response<IEnumerable<Team>>();
-			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
+    public async Task<Response<IEnumerable<Team>>> GetAuthorizedTeams()
+    {
+      var response = new Response<IEnumerable<Team>>();
+      client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
-			var request = await client.GetAsync($"{Endpoint}/team");
-			var httpResponse = await request.Content.ReadAsStringAsync();
+      var request = await client.GetAsync($"{Endpoint}/team");
+      var httpResponse = await request.Content.ReadAsStringAsync();
 
-			response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
-			if (!response.Error.IsError)
-			{
-				var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
-				response.Value = myDeserializedClass.teams;
-			}
+      response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
+      if (!response.Error.IsError)
+      {
+        var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
+        response.Value = myDeserializedClass.teams;
+      }
 
-			//Console.WriteLine(response);
-			return response;
-		}
+      //Console.WriteLine(response);
+      return response;
+    }
 
-		#endregion [ Authorization ]
+    #endregion [ Authorization ]
 
-		#region [ Attachments ]
+    #region [ Attachments ]
 
-		//TODO: CreateTaskAttachment()
-		//public async Task<Response<Type>> CreateTaskAttachment()
-		//{
-		//	var response = new Response<Type>();
-		//	client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
+    //TODO: CreateTaskAttachment()
+    //public async Task<Response<Type>> CreateTaskAttachment()
+    //{
+    //	var response = new Response<Type>();
+    //	client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
-		// Build parameter string
+    // Build parameter string
 
-		//	var request = await client.GetAsync("ENDPOINT");
-		//	var httpResponse = await request.Content.ReadAsStringAsync();
+    //	var request = await client.GetAsync("ENDPOINT");
+    //	var httpResponse = await request.Content.ReadAsStringAsync();
 
-		//	response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
-		//	if (!response.Error.IsError)
-		//	{
-		//		var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
-		//		response.Value = myDeserializedClass.Type;
-		//	}
+    //	response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
+    //	if (!response.Error.IsError)
+    //	{
+    //		var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
+    //		response.Value = myDeserializedClass.Type;
+    //	}
 
-		//	//Console.WriteLine(response);
-		//	return response;
-		//}
+    //	//Console.WriteLine(response);
+    //	return response;
+    //}
 
-		#endregion [ Attachments ]
+    #endregion [ Attachments ]
 
-		#region [ Comments ]
+    #region [ Comments ]
 
-		public async Task<Response<IEnumerable<Comment>>> GetTaskComments(string task_id, bool custom_task_ids = default, double team_id = default, int start = default, string start_id = default)
-		{
-			var response = new Response<IEnumerable<Comment>>();
-			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
+    public async Task<Response<IEnumerable<Comment>>> GetTaskComments(string task_id, bool custom_task_ids = default, double team_id = default, int start = default, string start_id = default)
+    {
+      var response = new Response<IEnumerable<Comment>>();
+      client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
-			#region [ Build parameter string ]
+      #region [ Build parameter string ]
 
-			StringBuilder parmBuilder = new StringBuilder();
-			if (custom_task_ids)
-			{
-				parmBuilder.Append("&custom_task_ids=true");
-				if (team_id != default)
-				{
-					parmBuilder.Append($"&team_id={team_id}");
-				}
-			}
+      StringBuilder parmBuilder = new StringBuilder();
+      if (custom_task_ids)
+      {
+        parmBuilder.Append("&custom_task_ids=true");
+        if (team_id != default)
+        {
+          parmBuilder.Append($"&team_id={team_id}");
+        }
+      }
 
-			if (start != default)
-			{
-				parmBuilder.Append($"&start={start}");
-			}
+      if (start != default)
+      {
+        parmBuilder.Append($"&start={start}");
+      }
 
-			if (start_id != default)
-			{
-				parmBuilder.Append($"&start_id={start_id}");
-			}
+      if (start_id != default)
+      {
+        parmBuilder.Append($"&start_id={start_id}");
+      }
 
-			string cleanParms = string.Empty;
-			if (parmBuilder.Length > 0)
-			{
-				// We've assumed an ampersand on all parms, but we really need to start with a question mark instead.
-				cleanParms = string.Concat("?", parmBuilder.ToString().AsSpan(1));
-			}
+      string cleanParms = string.Empty;
+      if (parmBuilder.Length > 0)
+      {
+        // We've assumed an ampersand on all parms, but we really need to start with a question mark instead.
+        cleanParms = string.Concat("?", parmBuilder.ToString().AsSpan(1));
+      }
 
-			#endregion [ Build parameter string ]
+      #endregion [ Build parameter string ]
 
-			var request = await client.GetAsync($"{Endpoint}/task/{task_id}/comment{cleanParms}");
-			var httpResponse = await request.Content.ReadAsStringAsync();
+      var request = await client.GetAsync($"{Endpoint}/task/{task_id}/comment{cleanParms}");
+      var httpResponse = await request.Content.ReadAsStringAsync();
 
-			response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
-			if (!response.Error.IsError)
-			{
-				var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
-				response.Value = myDeserializedClass.comments;
-			}
+      response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
+      if (!response.Error.IsError)
+      {
+        var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
+        response.Value = myDeserializedClass.comments;
+      }
 
-			//Console.WriteLine(httpResponse);
-			return response;
-		}
+      //Console.WriteLine(httpResponse);
+      return response;
+    }
 
-		#endregion [ Comments ]
+    #endregion [ Comments ]
 
-		#region [ Spaces ]
-		
-		public async Task<Response<IEnumerable<Space>>> GetSpaces (double team_id, bool archived = false)
-		{
-			var response = new Response<IEnumerable<Space>>();
-			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
+    #region [ Spaces ]
 
-			#region [ Build parameter string ]
+    public async Task<Response<IEnumerable<Space>>> GetSpaces(double team_id, bool archived = false)
+    {
+      var response = new Response<IEnumerable<Space>>();
+      client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
-			StringBuilder parmBuilder = new StringBuilder();
+      #region [ Build parameter string ]
 
-			if (archived)
-			{
-				parmBuilder.Append("&archived=true");
-			}
+      StringBuilder parmBuilder = new StringBuilder();
 
-			string cleanParms = string.Empty;
-			if (parmBuilder.Length > 0)
-			{
-				// We've assumed an ampersand on all parms, but we really need to start with a question mark instead.
-				cleanParms = string.Concat("?", parmBuilder.ToString().AsSpan(1));
-			}
+      if (archived)
+      {
+        parmBuilder.Append("&archived=true");
+      }
 
-			#endregion [ Build parameter string ]
+      string cleanParms = string.Empty;
+      if (parmBuilder.Length > 0)
+      {
+        // We've assumed an ampersand on all parms, but we really need to start with a question mark instead.
+        cleanParms = string.Concat("?", parmBuilder.ToString().AsSpan(1));
+      }
 
-			var request = await client.GetAsync($"{Endpoint}/team/{team_id}/space{cleanParms}");
-			var httpResponse = await request.Content.ReadAsStringAsync();
+      #endregion [ Build parameter string ]
 
-			response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
-			if (!response.Error.IsError)
-			{
-				var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
-				response.Value = myDeserializedClass.spaces;
-			}
+      var request = await client.GetAsync($"{Endpoint}/team/{team_id}/space{cleanParms}");
+      var httpResponse = await request.Content.ReadAsStringAsync();
 
-			//Console.WriteLine(httpResponse);
-			return response;
-		}
+      response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
+      if (!response.Error.IsError)
+      {
+        var myDeserializedClass = JsonSerializer.Deserialize<ClickUpContext>(httpResponse);
+        response.Value = myDeserializedClass.spaces;
+      }
 
-		public async Task<Response<Space>> GetSpace(double space_id)
-		{
-			var response = new Response<Space>();
-			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
+      //Console.WriteLine(httpResponse);
+      return response;
+    }
 
-			var request = await client.GetAsync($"{Endpoint}/space/{space_id}");
-			var httpResponse = await request.Content.ReadAsStringAsync();
+    public async Task<Response<Space>> GetSpace(double space_id)
+    {
+      var response = new Response<Space>();
+      client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
-			response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
-			if (!response.Error.IsError)
-			{
-				var myDeserializedClass = JsonSerializer.Deserialize<Space>(httpResponse);
-				Debug.WriteLine(httpResponse);
-				response.Value = myDeserializedClass;
-			}
+      var request = await client.GetAsync($"{Endpoint}/space/{space_id}");
+      var httpResponse = await request.Content.ReadAsStringAsync();
 
-			//Console.WriteLine(httpResponse);
-			return response;
-		}
+      response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
+      if (!response.Error.IsError)
+      {
+        var myDeserializedClass = JsonSerializer.Deserialize<Space>(httpResponse);
+        Debug.WriteLine(httpResponse);
+        response.Value = myDeserializedClass;
+      }
 
-		public async Task<Response> DeleteSpace(double space_id)
-		{
-			var response = new Response();
-			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
+      //Console.WriteLine(httpResponse);
+      return response;
+    }
 
-			var request = await client.DeleteAsync($"{Endpoint}/space/{space_id}");
-			var httpResponse = await request.Content.ReadAsStringAsync();
+    public async Task<Response> DeleteSpace(double space_id)
+    {
+      var response = new Response();
+      client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
-			response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
+      var request = await client.DeleteAsync($"{Endpoint}/space/{space_id}");
+      var httpResponse = await request.Content.ReadAsStringAsync();
 
-			//Console.WriteLine(httpResponse);
-			return response;
-		}
+      response.Error = JsonSerializer.Deserialize<ErrorResult>(httpResponse);
 
-		#endregion [ Spaces ]
+      //Console.WriteLine(httpResponse);
+      return response;
+    }
 
-		public async Task GetUpdatedTasks()
-		{
-			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
-			var ListId = "YOUR_list_id_PARAMETER";
-			var request = await client.GetAsync($"{Endpoint}/list/{ListId}/task?archived=false&page=0&order_by=string&reverse=true&subtasks=true&statuses=string&include_closed=true&assignees=string&tags=string&due_date_gt=0&due_date_lt=0&date_created_gt=0&date_created_lt=0&date_updated_gt=0&date_updated_lt=0&date_done_gt=0&date_done_lt=0&custom_fields=string");
-			var response = await request.Content.ReadAsStringAsync();
+    #endregion [ Spaces ]
 
-			Console.WriteLine(response);
-		}
+    public async Task GetUpdatedTasks()
+    {
+      client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
+      var ListId = "YOUR_list_id_PARAMETER";
+      var request = await client.GetAsync($"{Endpoint}/list/{ListId}/task?archived=false&page=0&order_by=string&reverse=true&subtasks=true&statuses=string&include_closed=true&assignees=string&tags=string&due_date_gt=0&due_date_lt=0&date_created_gt=0&date_created_lt=0&date_updated_gt=0&date_updated_lt=0&date_done_gt=0&date_done_lt=0&custom_fields=string");
+      var response = await request.Content.ReadAsStringAsync();
 
-		public ClickUpApi WithPersonalToken(string token)
-		{
-			Token = token;
-			ApiKeys.PersonalToken = token;
-			return this;
+      Console.WriteLine(response);
+    }
+
+    public ClickUpApi WithPersonalToken(string token)
+    {
+      Token = token;
+      ApiKeys.PersonalToken = token;
+      return this;
     }
 
     public ClickUpApi WithClientSecret(string secret)

--- a/ClickUp.Net/ClickUpApi.cs
+++ b/ClickUp.Net/ClickUpApi.cs
@@ -37,7 +37,35 @@ namespace Boson.ClickUp.Net
 			#endregion [ Load settings ]
 		}
 
-		public ClickUpApi UsingMockServer()
+    public ClickUpApi(string clientId, string clientSecret, string personalToken)
+    {
+      var handler = new SocketsHttpHandler
+      {
+        PooledConnectionLifetime = TimeSpan.FromMinutes(15) // Recreate every 15 minutes
+      };
+      client = new HttpClient(handler);
+			
+			ApiKeys = new ApiKeys()
+			{
+				ClientID = clientId,
+				ClientSecret = clientSecret,
+				PersonalToken = personalToken
+			};
+
+      #region [ Load settings ]
+
+      //var settingsPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(ClickUpApi)).Location);
+      //var settingsFile = "appsettings.json";
+      //var settingsData = File.ReadAllText(Path.Combine(settingsPath, settingsFile));
+      //var settings = JsonSerializer.Deserialize<Settings>(settingsData);
+      //var settings = new Settings();
+      //settings.PersonalToken = "pk_57147343_2AJ8N0LLIOPU8FYDFFK2MYPQ1OD5L43L";
+      //Token = settings.PersonalToken;
+
+      #endregion [ Load settings ]
+    }
+
+    public ClickUpApi UsingMockServer()
 		{
 			Endpoint = ApiMockServer;
 			return this;
@@ -63,7 +91,7 @@ namespace Boson.ClickUp.Net
 		public async Task<Response<User>> GetAuthorizedUser()
 		{
 			var response = new Response<User>();
-			client.DefaultRequestHeaders.Add("Authorization", Token);
+			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
 			var request = await client.GetAsync($"{Endpoint}/user");
 			var httpResponse = await request.Content.ReadAsStringAsync();
@@ -82,7 +110,7 @@ namespace Boson.ClickUp.Net
 		public async Task<Response<IEnumerable<Team>>> GetAuthorizedTeams()
 		{
 			var response = new Response<IEnumerable<Team>>();
-			client.DefaultRequestHeaders.Add("Authorization", Token);
+			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
 			var request = await client.GetAsync($"{Endpoint}/team");
 			var httpResponse = await request.Content.ReadAsStringAsync();
@@ -106,7 +134,7 @@ namespace Boson.ClickUp.Net
 		//public async Task<Response<Type>> CreateTaskAttachment()
 		//{
 		//	var response = new Response<Type>();
-		//	client.DefaultRequestHeaders.Add("Authorization", Token);
+		//	client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
 		// Build parameter string
 
@@ -131,7 +159,7 @@ namespace Boson.ClickUp.Net
 		public async Task<Response<IEnumerable<Comment>>> GetTaskComments(string task_id, bool custom_task_ids = default, double team_id = default, int start = default, string start_id = default)
 		{
 			var response = new Response<IEnumerable<Comment>>();
-			client.DefaultRequestHeaders.Add("Authorization", Token);
+			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
 			#region [ Build parameter string ]
 
@@ -185,7 +213,7 @@ namespace Boson.ClickUp.Net
 		public async Task<Response<IEnumerable<Space>>> GetSpaces (double team_id, bool archived = false)
 		{
 			var response = new Response<IEnumerable<Space>>();
-			client.DefaultRequestHeaders.Add("Authorization", Token);
+			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
 			#region [ Build parameter string ]
 
@@ -222,7 +250,7 @@ namespace Boson.ClickUp.Net
 		public async Task<Response<Space>> GetSpace(double space_id)
 		{
 			var response = new Response<Space>();
-			client.DefaultRequestHeaders.Add("Authorization", Token);
+			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
 			var request = await client.GetAsync($"{Endpoint}/space/{space_id}");
 			var httpResponse = await request.Content.ReadAsStringAsync();
@@ -242,7 +270,7 @@ namespace Boson.ClickUp.Net
 		public async Task<Response> DeleteSpace(double space_id)
 		{
 			var response = new Response();
-			client.DefaultRequestHeaders.Add("Authorization", Token);
+			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 
 			var request = await client.DeleteAsync($"{Endpoint}/space/{space_id}");
 			var httpResponse = await request.Content.ReadAsStringAsync();
@@ -257,7 +285,7 @@ namespace Boson.ClickUp.Net
 
 		public async Task GetUpdatedTasks()
 		{
-			client.DefaultRequestHeaders.Add("Authorization", Token);
+			client.DefaultRequestHeaders.Add("Authorization", ApiKeys.PersonalToken);
 			var ListId = "YOUR_list_id_PARAMETER";
 			var request = await client.GetAsync($"{Endpoint}/list/{ListId}/task?archived=false&page=0&order_by=string&reverse=true&subtasks=true&statuses=string&include_closed=true&assignees=string&tags=string&due_date_gt=0&due_date_lt=0&date_created_gt=0&date_created_lt=0&date_updated_gt=0&date_updated_lt=0&date_done_gt=0&date_done_lt=0&custom_fields=string");
 			var response = await request.Content.ReadAsStringAsync();
@@ -268,7 +296,20 @@ namespace Boson.ClickUp.Net
 		public ClickUpApi WithPersonalToken(string token)
 		{
 			Token = token;
+			ApiKeys.PersonalToken = token;
 			return this;
-		}
-	}
+    }
+
+    public ClickUpApi WithClientSecret(string secret)
+    {
+      ApiKeys.ClientSecret = secret;
+      return this;
+    }
+
+    public ClickUpApi WithClientId(string id)
+    {
+      ApiKeys.ClientID = id;
+      return this;
+    }
+  }
 }


### PR DESCRIPTION
- Added a constructor with properties for ApiKeys
- Added fluent methods to set ApiKeys properties
- Changed implementation of Auth header to use `ApiKeys.PersonalToken` instead of main class property.  Might have overstepped on this one, but it seems to be the auth token you're using there, so I figured if we're setting that token in ApiKeys, why have it in the main class as well?  **Decline the PR and let me know if you want me to revert this part.**

Edit: meant to add, all tests pass.  Didn't add any new tests for this one since it's all about private properties